### PR TITLE
Change wording of main page and add Hacktually section

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -31,7 +31,7 @@ a {
   padding-bottom: 10vh ;
   
 }
-.Tracks-title, .About-HM-Title{
+.Tracks-title, .About-HM-Title, .Hacktually-title {
   margin-top: 0;
   font-family: 'K2D';
   font-weight:bold;
@@ -42,7 +42,7 @@ a {
   position: absolute;
   
 }
-.Tracks-Flex, .About-HM-Contents  {
+.Tracks-Flex, .About-HM-Contents {
   justify-content: center;
   display: flex;
   padding-top: 1rem;
@@ -586,6 +586,58 @@ a {
 #mlh-trust-badge{
   left: 50px;
 }
+
+.Hacktually {
+  /* border:1px solid white; */
+  background: radial-gradient(50% 50% at 50% 50%, #CF8139, #C0593A, #342153);
+  background-blend-mode: overlay;
+  mix-blend-mode: normal;
+  backdrop-filter: blur(6px);
+  color:white;
+  height:100vh;
+  max-width: 100vw;
+  align-items: center;
+  text-align: center;
+  padding-bottom: 10vh ;
+  margin-top:0;
+}
+
+.Hacktually-Grid {
+  display:grid;
+  grid-template-columns:repeat(2, minmax(20vw, 30vw)); /* minmax() for responsivity */
+  grid-template-rows:3;
+  column-gap: 10vw;
+  row-gap: 8vw;
+  margin:5vw 0 0 15vw;
+  justify-items:center;
+  align-items:center;
+}
+
+.Hacktually-title {
+  position:inherit;
+}
+
+.Hacktually-infobox {
+  text-align:justify;
+  margin:0 5em 0 15%;
+  /* border:2px solid rgba(255, 255, 255, 0.5); */
+  background:rgba(255, 255, 255, 0.5);
+  border-radius: 10% 20% 30% 40% / 40% 30% 20% 10%;
+}
+
+.Hacktually-info {
+  padding:8vw;
+  background:rgba(255, 255, 255, 0.2);
+  padding:4em;
+  background-blend-mode: soft-light;
+  transition:border-radius 0.3s ease;
+}
+.Hacktually-info:nth-of-type(odd) { border-radius: 50% 70% 35%; }
+.Hacktually-info:nth-of-type(even) { border-radius:90% 50% 70%; }
+.Hacktually-info:nth-of-type(even):hover { border-radius:40% 25% 85%; }
+.Hacktually-info:nth-of-type(odd):hover { border-radius:85% 40% 25%; }
+
+
 /*MOBILE VIEWPORTS*/
 @media screen and (min-width: 300px) and (max-width: 880px) {
   .MainPage{
@@ -771,5 +823,14 @@ a {
   }
   #mlh-trust-badge img{
     width:max-content;
+  }
+  .Hacktually-info {
+    padding:10px;
+    border-radius:4px !important;
+  }
+  .Hacktually-Grid {
+    column-gap: 10vw;
+    row-gap: 8vw;
+    margin:5vw 0 0 10vw;
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -604,13 +604,14 @@ a {
 
 .Hacktually-Grid {
   display:grid;
-  grid-template-columns:repeat(2, minmax(20vw, 30vw));
+  grid-template-columns:repeat(2, minmax(20vw, 35vw));
   grid-template-rows:3;
   column-gap: 10vw;
   row-gap: 8vw;
-  margin:5vw 0 0 15vw;
+  margin:5vw 0 0 10vw;
   justify-items:center;
   align-items:center;
+  font-size:1.2em;
 }
 
 .Hacktually-title {
@@ -836,5 +837,6 @@ a {
     grid-template-columns: repeat(2, 40vw);
     row-gap: 8vw;
     margin:5vw 0 0 8vw;
+    font-size:1em;
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -212,6 +212,7 @@ a {
   font-family: 'K2D';
   font-weight: bold;
   font-size: 1em;
+  width:fit-content;
 }
 
 .nav-items > li{

--- a/src/App.css
+++ b/src/App.css
@@ -604,7 +604,7 @@ a {
 
 .Hacktually-Grid {
   display:grid;
-  grid-template-columns:repeat(2, minmax(20vw, 30vw)); /* minmax() for responsivity */
+  grid-template-columns:repeat(2, minmax(20vw, 30vw));
   grid-template-rows:3;
   column-gap: 10vw;
   row-gap: 8vw;
@@ -824,13 +824,17 @@ a {
   #mlh-trust-badge img{
     width:max-content;
   }
+  .Hacktually {
+    height:fit-content !important;
+  }
   .Hacktually-info {
-    padding:10px;
+    padding:30px;
     border-radius:4px !important;
   }
   .Hacktually-Grid {
-    column-gap: 10vw;
+    column-gap: 5vw;
+    grid-template-columns: repeat(2, 40vw);
     row-gap: 8vw;
-    margin:5vw 0 0 10vw;
+    margin:5vw 0 0 8vw;
   }
 }

--- a/src/Components/Hacktually.js
+++ b/src/Components/Hacktually.js
@@ -4,10 +4,10 @@ function Hacktually() {
         <h2 className ="Hacktually-title">hacktually</h2>
         <div className="Hacktually-Grid">
           <div className="Hacktually-info">Hacktually is a workshop-based day of learning to prepare for the upcoming HackMerced X and to meet like-minded coders and engineers.</div>
-          <div className="Hacktually-info">UC Merced COB2 110, 130 and 140 <br/>Saturday, November 2nd 9am-5pm</div>
-          <div className="Hacktually-info">Food will be available at noon</div>
+          <div className="Hacktually-info">UC Merced COB2 110, 130 and 140 <br/>Saturday, November 2nd 10am-6pm<br/>Food will be available at noon</div>
+          <div className="Hacktually-info">Join our <a href="https://discord.gg/ShRCuvHcYk" target="_blank" rel="noreferrer">Discord</a> to stay up to date</div>
           <div className="Hacktually-info">Learn CSS, UI/UX, NodeJS, React, Git, Bash, Firebase and more!</div>
-        </div> 
+        </div>
       </div>
     );
   }

--- a/src/Components/Hacktually.js
+++ b/src/Components/Hacktually.js
@@ -4,9 +4,9 @@ function Hacktually() {
         <h2 className ="Hacktually-title">hacktually</h2>
         <div className="Hacktually-Grid">
           <div className="Hacktually-info">Hacktually is a workshop-based day of learning to prepare for the upcoming HackMerced X and to meet like-minded coders and engineers.</div>
-          <div className="Hacktually-info">UC Merced COB2 110, 130 and 140 <br/>Saturday, November 2nd 10am-6pm<br/>Food will be available at noon</div>
+          <div className="Hacktually-info">Saturday Nov. 2nd 10am - 6pm, at UC Merced COB2 130. Food available at noon.</div>
           <div className="Hacktually-info">Join our <a href="https://discord.gg/ShRCuvHcYk" target="_blank" rel="noreferrer">Discord</a> to stay up to date</div>
-          <div className="Hacktually-info">Learn CSS, UI/UX, NodeJS, React, Git, Bash, Firebase and more!</div>
+          <div className="Hacktually-info">Workshop schedule coming soon!</div>
         </div>
       </div>
     );

--- a/src/Components/Hacktually.js
+++ b/src/Components/Hacktually.js
@@ -1,0 +1,15 @@
+function Hacktually() {
+    return (
+      <div className="Hacktually" id="hacktually">
+        <h2 className ="Hacktually-title">hacktually</h2>
+        <div className="Hacktually-Grid">
+          <div className="Hacktually-info">Hacktually is a workshop-based day of learning to prepare for the upcoming HackMerced X and to meet like-minded coders and engineers.</div>
+          <div className="Hacktually-info">UC Merced COB2 110, 130 and 140 <br/>Saturday, November 2nd 9am-5pm</div>
+          <div className="Hacktually-info">Food will be available at noon</div>
+          <div className="Hacktually-info">Learn CSS, UI/UX, NodeJS, React, Git, Bash, Firebase and more!</div>
+        </div> 
+      </div>
+    );
+  }
+  
+  export default Hacktually;

--- a/src/Components/HomePage.js
+++ b/src/Components/HomePage.js
@@ -3,12 +3,14 @@ import MainPage from './MainPage.js';
 import Tracks from './Tracks.js';
 import FAQ from './FAQ.js';
 import Sponsors from './Sponsors.js';
+import Hacktually from './Hacktually.js';
 
 function HomePage() {
   return (
     <div>
       <MainPage/>
       <Tracks/>
+      <Hacktually/>
       <FAQ/>
       <Sponsors/>
     </div>

--- a/src/Components/HomePage.js
+++ b/src/Components/HomePage.js
@@ -9,8 +9,8 @@ function HomePage() {
   return (
     <div>
       <MainPage/>
-      <Tracks/>
       <Hacktually/>
+      <Tracks/>
       <FAQ/>
       <Sponsors/>
     </div>

--- a/src/Components/MainPage.js
+++ b/src/Components/MainPage.js
@@ -13,9 +13,18 @@ function MainPage() {
                   <br/>
                   Learn from our workshops and connect with like-minded students and coders
                 </p>
-                <a className="registerButton2" href="./#hacktually">
-                {/* <a className="registerButton2" onClick={scrollToHacktually()}> */}
+                <a className="registerButton2Stars" href="./#hacktually">
                   <button className="registerButton2">Learn more</button>
+                  {/* <div class="starWrapper">
+                    <p class="star1" id="star">★</p>
+                    <p class="star2" id="star">★</p>
+                    <p class="star3" id="star">★</p>
+                  </div>
+                  <div class="starBursts">
+                    <p class="starBurst1">✨</p>
+                    <p class="starBurst2">⭐️</p>
+                    <p class="starBurst3">🌟</p>
+                  </div> */}
                 </a>
                 <p className="Main-footer">Have questions? Email <a className="Main-footerlink" href="mailto:general@hackmerced.com"> general@hackmerced.com <p className="emailEmoji">📧</p></a></p>
                 </div>

--- a/src/Components/MainPage.js
+++ b/src/Components/MainPage.js
@@ -1,35 +1,21 @@
 function MainPage() {
+  // function scrollToHacktually() {
+    // document.getElementById('hacktually').scrollIntoView({behavior: 'smooth', block:'end', alignToTop:false})
+  // }
     return (
       <div className="MainPage">
 
             <div className="Main-text-background">
               <div className="Main-text">
-                <h1 className="Main-title">HackMerced X</h1>
+                <h1 className="Main-title">Hacktually @ UC Merced</h1>
                 <p className="Main-subtitle">
-                  largest hackathon in the San Joaquin Valley
+                  Join us at Hacktually on November 2nd!
                   <br/>
-                  HackMerced X Coming Soon 2025 @ UC Merced
+                  Learn from our workshops and connect with like-minded students and coders
                 </p>
-                <p className="Main-subtitle">
-                  Applications to join our team are Open!
-                  <br/>
-                  Apply to help make HackMerced X come to fruition!
-                </p>
-                <a className="registerButton2Stars" href="https://docs.google.com/forms/d/e/1FAIpQLSd7K6NUy1IWhxdTOlP_40LQLvO-9S1cIRlE_KQlPj6xkFf3dg/viewform?usp=sf_link">
-                  <button className="registerButton2">Apply Now!</button>
-                  
-                  <div className="starWrapper">
-                    <p className="star1" id="star">★</p>
-                    <p className="star2" id="star">★</p>
-                    <p className="star3" id="star">★</p>
-                  </div>
-                  <div className="starBursts">
-                    <p className="starBurst1">✨</p>
-                    <p className="starBurst2">⭐️</p>
-                    <p className="starBurst3">🌟</p>
-                  </div>
-                 
-                  
+                <a className="registerButton2" href="./#hacktually">
+                {/* <a className="registerButton2" onClick={scrollToHacktually()}> */}
+                  <button className="registerButton2">Learn more</button>
                 </a>
                 <p className="Main-footer">Have questions? Email <a className="Main-footerlink" href="mailto:general@hackmerced.com"> general@hackmerced.com <p className="emailEmoji">📧</p></a></p>
                 </div>

--- a/src/Components/NavBar.js
+++ b/src/Components/NavBar.js
@@ -8,7 +8,7 @@ function NavBar() {
           <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSdsinPEX__G-Jr2kUgGIHNpwZyTA3VWYx4NPGU8X320Xa47rg/viewform"><button className="button" id="mentor-button">mentor</button></a></li>
           <li><Link to="/aboutus"><button className="button" id="about-us-button">about us</button></Link></li>
           <li><Link to="/contactus"><button className="button" id="contact-us-button">contact us</button></Link></li>
-          <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSd7K6NUy1IWhxdTOlP_40LQLvO-9S1cIRlE_KQlPj6xkFf3dg/viewform?usp=sf_link"><button className="registerButton" id="register-button">Apply Now!</button></a></li>
+          <li><a href="/#hacktually"><button className="registerButton" id="register-button">Hacktually</button></a></li>
         </ul>
             
       </div>


### PR DESCRIPTION

New feature:
- Changes main page wording away from recruitment to Hacktually
- Adds a proper section for Hacktually information (linking to community discord)
- Solves for #4 

Should look good on mobile too. Tested on Firefox and Safari but I'm not doing anything fancy that should cause cross browser issues.

<img width="1259" alt="Screenshot 2024-10-18 at 10 01 08" src="https://github.com/user-attachments/assets/677c7437-049b-4a40-879e-116e68368a4a">

<img width="1259" alt="Screenshot 2024-10-18 at 10 01 28" src="https://github.com/user-attachments/assets/d0a263b8-8ae0-480b-bbd3-5262e7297613">